### PR TITLE
Don't greedily boldface all strings ending with colons, just the defined labels

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,19 @@ $readme = preg_replace( "|^==([^=]+)=*?\s*?\n|im",  '##$1##'."\n",    $readme );
 $readme = preg_replace( "|^===([^=]+)=*?\s*?\n|im", '#$1#'."\n",   $readme );
 
 //parse contributors, donate link, etc.
-$readme = preg_replace( "|^([^:\n#]+): (.+)$|im", "**$1:** $2  ", $readme );
+$labels = array(
+	'Contributors',
+	'Donate link',
+	'Tags',
+	'Requires at least',
+	'Tested up to',
+	'Stable tag',
+	'License',
+	'License URI',
+);
+foreach ( $labels as $label ) {
+	$readme = preg_replace( "|^($label): (.+)$|im", "**$1:** $2  ", $readme );
+}
 
 //guess plugin slug from plugin name
 //@todo better way to do this?


### PR DESCRIPTION
If you have any lines later in your Readme that happen to contain colons, it gets pretty ugly.

Example:

```
1. Set up the WordPress testing library as described in [Handbook: Automated Testing (http://make.wordpress.org/core/handbook/automated-testing/).
```

Becomes:

```
**1. Set up the WordPress testing library as described in [Handbook:** Automated Testing](http://make.wordpress.org/core/handbook/automated-testing/).
```

Instead of greedily matching any line with a colon, this patch only matches the labels defined in the [Readme standard](http://wordpress.org/plugins/about/readme.txt).
