### PR TITLE
Change screenshot basedir and support all screenshot formats, as well as screenshots in /assets

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,10 +46,14 @@ if ( preg_match( "|## Screenshots ##(.*?)## [a-z]+ ##|ism", $readme, $matches ) 
 	preg_match_all( "|^[0-9]+\. (.*)$|im", $matches[1], $screenshots, PREG_SET_ORDER );
 
 	//replace list item with markdown image syntax, hotlinking to plugin repo
-	//@todo assumes .png, perhaps should check that file exists first?
 	$i = 1;
 	foreach ( $screenshots as $screenshot ) {
-		$readme = str_replace( $screenshot[0], "###{$i}. {$screenshot[1]}###\n![{$screenshot[1]}](http://s.wordpress.org/plugins/{$plugin}/screenshot-{$i}.png)\n", $readme );
+		$screenshot_url = find_screenshot( $i, $plugin );
+		if ( $screenshot_url ) {
+			$readme = str_replace( $screenshot[0], "###{$i}. {$screenshot[1]}###\n![{$screenshot[1]}](" . $screenshot_url . ")\n", $readme );
+		} else {
+			$readme = str_replace( $screenshot[0], "###{$i}. {$screenshot[1]}###\n[missing image]\n", $readme );
+		}
 		$i++;
 	}
 
@@ -59,3 +63,99 @@ header('Content-disposition: attachment; filename=readme.md');
 header('Content-type: ' . $_FILES['file']['type'] );
 
 echo $readme;
+
+
+/**
+* Finds the correct screenshot file with the given number and plugin slug.
+* 
+* As per the WordPress plugin repo, file extensions may be any
+* of: (png|jpg|jpeg|gif).  We look in the /assets directory first,
+* then in the base directory.
+*
+* @param   int     $number       Screenshot number to look for
+* @param   string  $plugin_slug
+* @return  mixed   Valid screenshot URL or false if none found
+* @uses    url_validate
+* @link    http://wordpress.org/plugins/about/readme.txt
+*/
+function find_screenshot( $number, $plugin_slug ) {
+	$extensions = array( 'png', 'jpg', 'jpeg', 'gif' );
+
+	// this seems to now be the correct URL, not s.wordpress.org/plugins
+	$base_url = 'http://s-plugins.wordpress.org/' . $plugin_slug . '/';
+	$assets_url = $base_url . 'assets/';
+
+	/* check assets for all extensions first, because if there's a
+	   gif in the assets directory and a jpg in the base directory,
+	   the one in the assets directory needs to win.
+	*/
+	foreach ( $extensions as $extension ) {
+		$filename = 'screenshot-' . $number . '.' . $extension;
+		if ( url_validate( $assets_url . $filename ) ) {
+			return $assets_url . $filename;
+		}
+	}
+
+	/* nothing found in /assets, check the base directory */
+	foreach ( $extensions as $extension ) {
+		$filename = 'screenshot-' . $number . '.' . $extension;
+		if ( url_validate( $base_url . $filename ) ) {
+			return $base_url . $filename;
+		}
+	}
+	return false;
+}
+
+/**
+* Test whether a file exists at the given URL.
+*
+* To do this as quickly as possible, we use fsockopen to just
+* get the HTTP headers and see if the response is "200 OK".
+* This is better than fopen (which would download the entire file)
+* and cURL (which might not be installed on all systems).
+*
+* @param    string    $link    URL to validate
+* @return   boolean
+* @link http://www.php.net/manual/en/function.fsockopen.php#39948
+*/
+function url_validate( $link ) {        
+	$url_parts = @parse_url( $link );
+
+	if ( empty( $url_parts["host"] ) ) {
+		return false;
+	}
+	$host = $url_parts["host"];
+
+	if ( ! empty( $url_parts["path"] ) ) {
+		$documentpath = $url_parts["path"];
+	} else {
+		$documentpath = "/";
+	}
+
+	if ( ! empty( $url_parts["query"] ) ) {
+		$documentpath .= "?" . $url_parts["query"];
+	}
+
+	if ( ! empty( $url_parts["port"] ) ) {
+		$port = $url_parts["port"];
+	}
+	else {
+		$port = "80";
+	}
+
+	$socket = @fsockopen( $host, $port, $errno, $errstr, 30 );
+
+	if ( ! $socket ) {
+		return false;
+	} else {
+		fwrite( $socket, "HEAD " . $documentpath . " HTTP/1.0\r\nHost: $host\r\n\r\n" );
+		$http_response = fgets( $socket, 22 );
+
+		if ( ereg( "200 OK", $http_response, $regs ) ) {
+			return true;
+			fclose( $socket );
+		} else {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
1) Change plugin basedir from s.wordpress.org/plugins to s-plugins.wordpress.org (the former seems to no longer exist).

2) Instead of assuming .png files located in the base directory, use fsockopen() to look for valid file URLs.

Following what the official plugin repo does, this first looks in /assets, then in the plugin's base directory, for any files with the extensions png, jpg, jpeg or gif.

If nothing was found, it leaves the description in the "Screenshots" section with a "missing image" note.
