### PR TITLE
new plugin screenshot base is http://s.w.org/plugins/

### DIFF
--- a/index.php
+++ b/index.php
@@ -101,7 +101,7 @@ function find_screenshot( $number, $plugin_slug ) {
 	$extensions = array( 'png', 'jpg', 'jpeg', 'gif' );
 
 	// this seems to now be the correct URL, not s.wordpress.org/plugins
-	$base_url = 'http://s.w.org/plugins/' . $plugin_slug . '/';
+	$base_url = 'https://s.w.org/plugins/' . $plugin_slug . '/';
 	$assets_url = $base_url . 'assets/';
 
 	/* check assets for all extensions first, because if there's a


### PR DESCRIPTION
The plugin screenshot base URL has changed again, since [WordPress moved static resources to s.w.org](http://wptavern.com/how-wordpress-obtained-the-w-org-domain).
